### PR TITLE
Remove init

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,5 @@ ADD ./wrapdocker /usr/local/bin/wrapdocker
 RUN chmod +x /usr/local/bin/wrapdocker
 
 # Define additional metadata for our image.
-VOLUME /var/lib/docker
 CMD ["wrapdocker"]
 

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-DOMAIN = "pivotal"
+DOMAIN = "dcapwell"
 NAME = "dcloud"
 VERSION = "0.1"
 
@@ -36,10 +36,14 @@ docker: docker-build docker-run
 # builds the docker image for dcloud
 docker-build:
 	@echo "Building docker image: $(DOMAIN)/$(NAME):$(VERSION)"
+	@docker build -t "$(DOMAIN)/dns_base:$(VERSION)" $(DOMAIN)/dns_base
+	@docker build -t "$(DOMAIN)/ssh_base:$(VERSION)" $(DOMAIN)/ssh_base
 	@docker build -t "$(DOMAIN)/$(NAME):$(VERSION)" .
 
 # push a existing dcloud image to the docker registry
 docker-push:
+	@docker push "$(DOMAIN)/dns_base"
+	@docker push "$(DOMAIN)/ssh_base"
 	@docker push "$(DOMAIN)/$(NAME)"
 
 # run dcloud in a docker container.

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,8 @@ uninstall:
 # install on the host environment
 docker: docker-build docker-run
 
+docker-release: docker-build docker-push
+
 # builds the docker image for dcloud
 docker-build:
 	@echo "Building docker image: $(NAMESPACE)/$(NAME):$(VERSION)"

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-DOMAIN = "dcapwell"
+DOMAIN = "dcloud"
 NAME = "dcloud"
 VERSION = "0.2"
 
@@ -36,14 +36,14 @@ docker: docker-build docker-run
 # builds the docker image for dcloud
 docker-build:
 	@echo "Building docker image: $(DOMAIN)/$(NAME):$(VERSION)"
-	@docker build -t "$(DOMAIN)/dns_base:$(VERSION)" $(DOMAIN)/dns_base
-	@docker build -t "$(DOMAIN)/ssh_base:$(VERSION)" $(DOMAIN)/ssh_base
+	@docker build -t "$(DOMAIN)/ssh-base:$(VERSION)" dcloud/ssh_base
+	@docker build -t "$(DOMAIN)/dns-base:$(VERSION)" dcloud/dns_base
 	@docker build -t "$(DOMAIN)/$(NAME):$(VERSION)" .
 
 # push a existing dcloud image to the docker registry
 docker-push:
-	@docker push "$(DOMAIN)/dns_base"
-	@docker push "$(DOMAIN)/ssh_base"
+	@docker push "$(DOMAIN)/ssh-base"
+	@docker push "$(DOMAIN)/dns-base"
 	@docker push "$(DOMAIN)/$(NAME)"
 
 # run dcloud in a docker container.

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 
 DOMAIN = "dcapwell"
 NAME = "dcloud"
-VERSION = "0.1"
+VERSION = "0.2"
 
 INSTALL_FILE = "installedFiles.txt"
 

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-DOMAIN = "dcloud"
+NAMESPACE = "dcloud"
 NAME = "dcloud"
 VERSION = "0.2"
 
@@ -35,19 +35,19 @@ docker: docker-build docker-run
 
 # builds the docker image for dcloud
 docker-build:
-	@echo "Building docker image: $(DOMAIN)/$(NAME):$(VERSION)"
-	@docker build -t "$(DOMAIN)/ssh-base:$(VERSION)" dcloud/ssh_base
-	@docker build -t "$(DOMAIN)/dns-base:$(VERSION)" dcloud/dns_base
-	@docker build -t "$(DOMAIN)/$(NAME):$(VERSION)" .
+	@echo "Building docker image: $(NAMESPACE)/$(NAME):$(VERSION)"
+	@docker build -t "$(NAMESPACE)/ssh-base:$(VERSION)" dcloud/ssh_base
+	@docker build -t "$(NAMESPACE)/dns-base:$(VERSION)" dcloud/dns_base
+	@docker build -t "$(NAMESPACE)/$(NAME):$(VERSION)" .
 
 # push a existing dcloud image to the docker registry
 docker-push:
-	@docker push "$(DOMAIN)/ssh-base"
-	@docker push "$(DOMAIN)/dns-base"
-	@docker push "$(DOMAIN)/$(NAME)"
+	@docker push "$(NAMESPACE)/ssh-base"
+	@docker push "$(NAMESPACE)/dns-base"
+	@docker push "$(NAMESPACE)/$(NAME)"
 
 # run dcloud in a docker container.
 # assumes that docker-build has already run for the given
 # domain/name/version
 docker-run:
-	@docker run -t -i --volume /var/lib/docker:/var/lib/docker --privileged "$(DOMAIN)/$(NAME):$(VERSION)"
+	@docker run -t -i --volume /var/lib/docker:/var/lib/docker --privileged "$(NAMESPACE)/$(NAME):$(VERSION)"

--- a/Makefile
+++ b/Makefile
@@ -50,4 +50,4 @@ docker-push:
 # assumes that docker-build has already run for the given
 # domain/name/version
 docker-run:
-	@docker run -t -i --privileged "$(DOMAIN)/$(NAME):$(VERSION)"
+	@docker run -t -i --volume /var/lib/docker:/var/lib/docker --privileged "$(DOMAIN)/$(NAME):$(VERSION)"

--- a/README.md
+++ b/README.md
@@ -101,17 +101,6 @@ How to use dcloud
 =======================
 Please note that you run dcloud command as root user at this point. We have a ticket to fix this limitation https://github.com/gopivotal/dcloud/issues/2
 
-Initialization
----------------
-Make sure docker service is running
-
-*init* command lets your environment create a few images that dcloud requires
-
-```
-service docker start
-dcloud init
-```
-
 How to create a dcloud cluster
 -----------------
 ### Example with image

--- a/dcloud/dcloud.py
+++ b/dcloud/dcloud.py
@@ -22,7 +22,7 @@ import docker
 from utils import ssh
 from utils import cmdutil
 
-DOMAIN = "dcapwell"
+DOMAIN = "dcloud"
 VERSION = "0.2"
 
 COMMAND_CREATE = "create"
@@ -33,7 +33,7 @@ COMMAND_SNAPSHOT = "snapshot"
 COMMAND_DELETESNAPSHOT = "deletesnapshot"
 COMMAND_ARCHIVE = "archive"
 
-REPO_DNS_BASE = "{0}/dns_base:{1}".format(DOMAIN, VERSION)
+REPO_DNS_BASE = "{0}/dns-base:{1}".format(DOMAIN, VERSION)
 
 class RunResult:
     dns = ""

--- a/dcloud/dcloud.py
+++ b/dcloud/dcloud.py
@@ -22,7 +22,7 @@ import docker
 from utils import ssh
 from utils import cmdutil
 
-DOMAIN = "dcloud"
+NAMESPACE = "dcloud"
 VERSION = "0.2"
 
 COMMAND_CREATE = "create"
@@ -33,7 +33,7 @@ COMMAND_SNAPSHOT = "snapshot"
 COMMAND_DELETESNAPSHOT = "deletesnapshot"
 COMMAND_ARCHIVE = "archive"
 
-REPO_DNS_BASE = "{0}/dns-base:{1}".format(DOMAIN, VERSION)
+REPO_DNS_BASE = "{0}/dns-base:{1}".format(NAMESPACE, VERSION)
 
 class RunResult:
     dns = ""

--- a/dcloud/dns_base/Dockerfile
+++ b/dcloud/dns_base/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM dcloud/ssh-base
+FROM dcloud/ssh-base:0.2
 
 RUN mkdir -p /etc/dcloud/dnsmasq
 

--- a/example/cluster_from_images.json
+++ b/example/cluster_from_images.json
@@ -5,7 +5,7 @@
 	"nodes": [
 		{
 			"hostname" : "node[1..3]",
-			"imageName" : "dcloud/ssh-base",
+			"imageName" : "dcloud/ssh-base:0.2",
 			"cmd" : "service sshd start && tail -f /var/log/yum.log"
 		}
 	]

--- a/wrapdocker
+++ b/wrapdocker
@@ -24,7 +24,7 @@ CGROUP=/sys/fs/cgroup
 
 mountpoint -q $CGROUP || 
 	mount -n -t tmpfs -o uid=0,gid=0,mode=0755 cgroup $CGROUP || {
-		echo "Could not make a tmpfs mount. Did you use -privileged?"
+		echo "Could not make a tmpfs mount. Did you use --privileged?"
 		exit 1
 	}
 
@@ -32,7 +32,7 @@ if [ -d /sys/kernel/security ] && ! mountpoint -q /sys/kernel/security
 then
     mount -t securityfs none /sys/kernel/security || {
         echo "Could not mount /sys/kernel/security."
-        echo "AppArmor detection and -privileged mode might break."
+        echo "AppArmor detection and --privileged mode might break."
     }
 fi
 
@@ -98,19 +98,10 @@ popd >/dev/null
 # delete it so that docker can start.
 rm -rf /var/run/docker.pid
 
-# If we were given a PORT environment variable, start as a simple daemon;
-# otherwise, spawn a shell as well
-if [ "$PORT" ]
-then
-	exec docker -d -H 0.0.0.0:$PORT
-  /usr/local/bin/dcloud init
+docker -d &>/var/log/docker.log &
+
+if [ $# -eq 0 ]; then
+  exec bash
 else
-	if [ "$LOG" == "file" ]
-	then
-		docker -d &>/var/log/docker.log &
-	else
-		docker -d &
-	fi
-  /usr/local/bin/dcloud init
-	exec bash
+  exec "$@"
 fi

--- a/wrapdocker
+++ b/wrapdocker
@@ -99,9 +99,4 @@ popd >/dev/null
 rm -rf /var/run/docker.pid
 
 docker -d &>/var/log/docker.log &
-
-if [ $# -eq 0 ]; then
-  exec bash
-else
-  exec "$@"
-fi
+exec bash


### PR DESCRIPTION
Removed the requirement of `dcloud init`.

This patch requires that dns-base is hosted on docker hub.  The `make docker` command will create the image `dcloud/dns-base`, so all you need to do is create the dcloud user in docker hub, and run `make docker-push`
