### PR TITLE
URL Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ https://www.docker.io/gettingstarted/#h_installation
 This is a handy unofficial note for Docker installation on Centos. Please refer to the Docker official page for detail.
 
 ```
-sudo yum install http://dl.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm
+sudo yum install https://dl.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm
 sudo yum update -y
 sudo yum -y install docker-io
 sudo service docker start

--- a/dcloud/dcloud.py
+++ b/dcloud/dcloud.py
@@ -348,7 +348,7 @@ def main():
         return 1
         
     if not docker.installed():
-        print "docker command is not available. Follow the installation document http://docs.docker.io/installation and install docker"
+        print "docker command is not available. Follow the installation document https://docs.docker.io/installation and install docker"
         return 1
 
     command = sys.argv[1]


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://dl.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm with 1 occurrences migrated to:  
  https://dl.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm ([https](https://dl.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm) result 200).
* http://docs.docker.io/installation with 1 occurrences migrated to:  
  https://docs.docker.io/installation ([https](https://docs.docker.io/installation) result 301).